### PR TITLE
Upgrade to python 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ lint: $(VENV)/pyvenv.cfg
 .PHONY: reformat
 reformat: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		ruff format src/ && \
-		ruff check --fix src/
+		ruff format --target-version py39 src/ && \
+		ruff check --fix --target-version py39 src/
 
 .PHONY: doc
 doc: $(VENV)/pyvenv.cfg

--- a/codegen/codegen.sh
+++ b/codegen/codegen.sh
@@ -66,8 +66,7 @@ for type in "${rekor_types[@]}"; do
         --input "${rekor_dir}/pkg/types/${type}/${type}_schema.json" \
         --input-file-type jsonschema \
         --target-python-version 3.9 \
-        --formatters ruff-check \
-        --formatters ruff-format \
+        --formatters black isort ruff-check ruff-format \
         --enable-version-header \
         --collapse-root-models \
         --snake-case-field \

--- a/codegen/codegen.sh
+++ b/codegen/codegen.sh
@@ -65,7 +65,9 @@ for type in "${rekor_types[@]}"; do
     datamodel-codegen \
         --input "${rekor_dir}/pkg/types/${type}/${type}_schema.json" \
         --input-file-type jsonschema \
-        --target-python-version 3.8 \
+        --target-python-version 3.9 \
+        --formatters ruff-check \
+        --formatters ruff-format \
         --enable-version-header \
         --collapse-root-models \
         --snake-case-field \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pydantic[email] >=2,<3",
     "typing-extensions; python_version < '3.9'",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 doc = ["pdoc >= 14.2,< 16.0"]


### PR DESCRIPTION
Upgrades to python 3.9

Python 3.8 is no longer supported in datamodel-codegen
 - https://github.com/koxudaxi/datamodel-code-generator/releases/tag/0.28.3

the current sigstore-python v3.6.2 uses python 3.9 at minimum
- https://github.com/sigstore/sigstore-python/blob/baa95acc60082ab37d22813890085d384c8a6d37/pyproject.toml#L46