### PR TITLE
Add signoff to automated bump commit

### DIFF
--- a/.github/workflows/bump-rekor.yml
+++ b/.github/workflows/bump-rekor.yml
@@ -41,6 +41,7 @@ jobs:
           commit-message: "[BOT] Regenerate for new Rekor version"
           branch: update-rekor
           title: "[BOT] bump Rekor"
+          signoff: true
           body: |
             This is an automated pull request, bumping the code generation
             to match the latest Rekor release.


### PR DESCRIPTION
Fixes failing CI on the automated Rekor bump PRs: https://github.com/sigstore/sigstore-rekor-types/pull/361